### PR TITLE
Add a disqus comments anchor for centillion

### DIFF
--- a/material/partials/integrations/disqus.html
+++ b/material/partials/integrations/disqus.html
@@ -3,6 +3,7 @@
   {% set disqus = page.meta.disqus %}
 {% endif %}
 {% if not page.is_homepage and disqus %}
+  <a name="disqus_comments"></a>
   <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
   <div id="disqus_thread"></div>
   <script>


### PR DESCRIPTION
Add an anchor to the page where disqus comments begin.

This makes it easier for centillion to link to the disqus comments on the page, instead of the top of the page.