### PR TITLE
add matomo analytics to version 2 of template

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -205,5 +205,8 @@
         {% include "partials/integrations/analytics.html" %}
       {% endif %}
     {% endblock %}
+    {% block matomo %}
+      {% include "partials/integrations/matomo.html" %}
+    {% endblock %}
   </body>
 </html>

--- a/material/base.html
+++ b/material/base.html
@@ -205,8 +205,5 @@
         {% include "partials/integrations/analytics.html" %}
       {% endif %}
     {% endblock %}
-    {% block matomo %}
-      {% include "partials/integrations/matomo.html" %}
-    {% endblock %}
   </body>
 </html>

--- a/material/partials/integrations/matomo.html
+++ b/material/partials/integrations/matomo.html
@@ -1,0 +1,18 @@
+{% set matomo_id = config.extra.matomo %}
+{% if matomo_id %}
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//copper.nihdatacommons.us/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '{{ matomo_id }}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+{% endif %}


### PR DESCRIPTION
This adds a matomo analytics footer.

To use this, start by setting up a matomo instance, currently at <https://copper.nihdatacommons.us>.

Maybe it should be moved to <https://matomo.nihdatacommons.us> or to <https://analytics.nihdatacommons.us>.

In any case, each site added to matomo has a numerical ID, so to use this, just indicate the integer ID in the `mkdocs` extras section:

```
extras:
    matomo: 5
```

will link to site ID 5 in the matomo instance at <https://copper.nihdatacommons.us>.

Modify `materials/partials/inclusion/matomo.html` if you want to set it up with a different matomo instance.

